### PR TITLE
SIG-2705 Fix incorrect default true properties

### DIFF
--- a/DTO/signer.php
+++ b/DTO/signer.php
@@ -91,12 +91,11 @@ class Signer implements JsonSerializable {
 	}
 
 	function jsonSerialize() {
-		return array_filter(array(
+		$filtered = array_filter(array(
 			"Id"                   => $this->Id,
 			"Email"                => $this->Email,
 			"Authentications"      => $this->Authentications,
 			"Verifications"        => $this->Verifications,
-			"SendSignRequest"      => $this->SendSignRequest,
 			"SignRequestMessage"   => $this->SignRequestMessage,
 			"SendSignConfirmation" => $this->SendSignConfirmation,
 			"Language"             => $this->Language,
@@ -107,5 +106,11 @@ class Signer implements JsonSerializable {
 			"ReturnUrl"            => $this->ReturnUrl,
 			"Context"              => $this->Context,
 		));
+
+		if ($this->SendSignRequest === false) {
+			$filtered["SendSignRequest"] = $this->SendSignRequest;
+		}
+
+		return $filtered;
 	}
 }

--- a/DTO/signer.php
+++ b/DTO/signer.php
@@ -63,7 +63,7 @@ class Signer implements JsonSerializable {
 		$id                   = null,
 		$authentications      = array(),
 		$verifications        = array(),
-		$sendSignRequest      = false,
+		$sendSignRequest      = true,
 		$signRequestMessage   = null,
 		$sendSignConfirmation = null,
 		$language             = "nl-NL",

--- a/DTO/transaction.php
+++ b/DTO/transaction.php
@@ -46,7 +46,7 @@ class Transaction implements JsonSerializable {
 		$postbackUrl            = null,
 		$signRequestMode        = 2,
 		$daysToExpire           = 60,
-		$sendEmailNotifications = false,
+		$sendEmailNotifications = true,
 		$context                = null
 	) {
 		$this->Seal                   = $seal;

--- a/DTO/transaction.php
+++ b/DTO/transaction.php
@@ -61,7 +61,7 @@ class Transaction implements JsonSerializable {
 	}
 
 	function jsonSerialize() {
-		return array_filter(array(
+		$filtered = array_filter(array(
 			"Seal"                   => $this->Seal,
 			"Signers"                => $this->Signers,
 			"Receivers"              => $this->Receivers,
@@ -69,8 +69,13 @@ class Transaction implements JsonSerializable {
 			"PostbackUrl"            => $this->PostbackUrl,
 			"SignRequestMode"        => $this->SignRequestMode,
 			"DaysToExpire"           => $this->DaysToExpire,
-			"SendEmailNotifications" => $this->SendEmailNotifications,
 			"Context"                => $this->Context,
 		));
+
+		if ($this->SendEmailNotifications === false) {
+			$filtered["SendEmailNotifications"] = $this->SendEmailNotifications;
+		}
+
+		return $filtered;
 	}
 }

--- a/signhost.php
+++ b/signhost.php
@@ -113,6 +113,7 @@ class SignHost {
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+			"Content-Length: 0",
 			"Accept: application/vnd.signhost.".self::API_VERSION."+json",
 			"User-Agent: Signhost PHP Client/".self::CLIENT_VERSION,
 			"Application: APPKey ".$this->AppKey,
@@ -135,6 +136,7 @@ class SignHost {
 		curl_setopt($ch, CURLOPT_PUT, 1);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+			"Content-Length: 0",
 			"Accept: application/vnd.signhost.".self::API_VERSION."+json",
 			"User-Agent: Signhost PHP Client/".self::CLIENT_VERSION,
 			"Application: APPKey ".$this->AppKey,


### PR DESCRIPTION
The properties SendSignRequest and SendEmailNotifications had a default value of false, but should have been true. We were also filtering out properties that were set to false, even if their default is true.

Fixes https://github.com/Evidos/signhost-phpdemoclient/issues/23